### PR TITLE
fix: FIFO queue to the name of .fifo suffix

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -359,6 +359,7 @@ Resources:
   SQSMeteringRecrods:
     Type: AWS::SQS::Queue
     Properties:
+      QueueName: !Join [ "-", [!Ref AWS::StackName, SQSMeteringRecrods.fifo]]
       ContentBasedDeduplication: true
       FifoQueue: true
       MessageRetentionPeriod: 3000


### PR DESCRIPTION
*Description of changes:*
The FIFO queue of SQSMeteringRecrods, is not explicitly named with a .fifo suffix (automatically generated by SAM).
As a result, the following error occurs and cannot be deployed.
```
The name of a FIFO queue can only include alphanumeric characters, hyphens, or underscores, must end with .fifo suffix and be 1 to 80 in length.
```

The name of the FIFO queue must have a .fifo suffix.
> QueueName
> A name for the queue. To create a FIFO queue, the name of your FIFO queue must end with the .fifo suffix. For more information, see FIFO (First-In-First-Out) Queues in the Amazon Simple Queue Service Developer Guide.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html

Explicitly name the FIFO queue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
