### PR TITLE
fix: contracts resources being defined as subscriptions resources

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -213,7 +213,7 @@ Resources:
       Environment:
         Variables:
           NewSubscribersTableName: !Ref NewSubscribersTableName
-          EntitlementQueueUrl: !If [CreateSubscriptionLogic, !Ref  EntitlementSQSQueue, '' ] 
+          EntitlementQueueUrl: !If [CreateEntitlementLogic, !Ref  EntitlementSQSQueue, '' ] 
       Policies:
         - DynamoDBWritePolicy:
             TableName: !Ref NewSubscribersTableName
@@ -239,7 +239,7 @@ Resources:
 
   EntitlementSQSQueue:
     Type: AWS::SQS::Queue
-    Condition: CreateSubscriptionLogic
+    Condition: CreateEntitlementLogic
 
   EntitlementSQSHandler:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
*Description of changes:*
`EntitlementSQSQueue` is a resource in contracts mode.
Fix it being defined as a resource in subscriptions mode.

The resource definition is based on this diagram.
[Diagram of created resources](https://github.com/aws-samples/aws-marketplace-serverless-saas-integration#diagram-of-created-resources)

The `EntitlementSQSQueue` is a purple circle, indicating that it is a contracts resource.
> In the case of a contracts, the resources market with orange circles will not be created.

This fix is required for contract mode deployments.
```
Error: Failed to create changeset for the stack: my-aws-marketplace-contract-integration-stack, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state Status: FAILED. Reason: Template format error: Unresolved resource dependencies [EntitlementSQSQueue] in the Resources block of the template
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
