### PR TITLE
fix: unnecessary policy definitions that interfere with deployments

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -254,8 +254,6 @@ Resources:
       Policies:
         - DynamoDBWritePolicy:
             TableName: !Ref NewSubscribersTableName
-        - SQSSendMessagePolicy:
-            QueueName: !GetAtt SQSMeteringRecrods.Arn
         - Statement:
             - Sid: AWSMarketplaceEntitlements
               Effect: Allow


### PR DESCRIPTION
*Description of changes:*
`EntitlementSQSHandler` does not use `SQSMeteringRecrods`.
Therefore, this is an unnecessary policy definition.

Deploying in contract mode will fail because of this definition
```
Error: Failed to create changeset for the stack: my-aws-marketplace-contracct-integration-stack, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state Status: FAILED. Reason: Template format error: Unresolved resource dependencies [SQSMeteringRecrods] in the Resources block of the template
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
