### PR TITLE
Fixed the invalid sample metering record

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We have created MeteringSchedule CloudWatch Event rule that is **triggered every
 All of the pending records are aggregated based on the customerIdentifier and dimension name, and sent to the SQSMetering queue.
 The records in the `AWSMarketplaceMeteringRecords` table are expected to be inserted programmatically by your SaaS application. In this case you will have to give permissions to the service in charge of collecting usage data in your existing SaaS product to be able to write to `AWSMarketplaceMeteringRecords` table. 
 
-The lambda function `metering-sqs.js` is sending all of the queued metering records to the AWS marketplace Metering API.
+The lambda function `metering-sqs.js` is sending all of the queued metering records to the AWS Marketplace Metering service.
 After every call to the `batchMeterUsage` endpoint the rows are updated in the AWSMarketplaceMeteringRecords table, with the response returned from the Metering Service, which can be found in the `metering_response` field. If the request was unsuccessful the metering_failed value with be set to true and you will have to investigate the issue the error will be also stored in the `metering_response` field.
 
 The new records in the AWSMarketplaceMeteringRecords table should be stored in the following format:
@@ -89,26 +89,46 @@ The new records in the AWSMarketplaceMeteringRecords table should be stored in t
 
 ```javascript
 {
-  "create_timestamp": 113123,
-  "customerIdentifier": "ifAPi5AcF3",
-  "dimension_usage": [
-    {
-      "dimension": "users",
-      "value": 3
-    },
-     {
-      "dimension": "admin_users",
-      "value": 1
-    }
-  ],
-  "metering_pending": "true"
+  "create_timestamp": {
+    "N": "113123"
+  },
+  "customerIdentifier": {
+    "S": "ifAPi5AcF3"
+  },
+  "dimension_usage": {
+    "L": [
+      {
+        "M": {
+          "dimension": {
+            "S": "users"
+          },
+          "value": {
+            "N": "3"
+          }
+        }
+      },
+      {
+        "M": {
+          "dimension": {
+            "S": "admin_users"
+          },
+          "value": {
+            "N": "1"
+          }
+        }
+      }
+    ]
+  },
+  "metering_pending": {
+    "S": "true"
+  }
 }
 ```
 
-Where the `create_timestamp` is the sort key and `customerIdentifier` is the partition key, and they are both forming the Primary key.
-The AWSMarketplaceMeteringRecords table
+Where the `create_timestamp` is the sort key and `customerIdentifier` is the partition key, and they are both forming the Primary key. 
+Note:The new records format is in DynamoDB JSON format. It is different than JSON. The accepted time stamp is UNIX timestamp in UTC time. 
 
-After the record is submitted to AWS Marketplace API, it will be updated and I.E. will look like this:
+After the record is submitted to AWS Marketplace BatchMeterUsage API, it will be updated and it will look like this:
 
 ```javascript
 {


### PR DESCRIPTION
The sample metering record was not in DynamoDB JSON format. Fixed the sample records format and added notes to describe the record format.


Describe the bug:

The Readme file provides a sample metering record format to submit the records to the Metering Records DynamoDB table created by the application. The below provided record format is invalid.

{
"create_timestamp": 113123,
"customerIdentifier": "ifAPi5AcF3",
"dimension_usage": [
{
"dimension": "users",
"value": 3
},
{
"dimension": "admin_users",
"value": 1
}
],
"metering_pending": "true"
}

To Reproduce
Steps to reproduce the behavior:
1.Deploy the serverless application with SaaS CCP or subscription model
2. Try to submit a dummy metering record in the format provided

Expected behavior
The document should provide the correct metering record format to be accepted by the metering DynamoDB table.

Desktop (please complete the following information):

    OS: [e.g. iOS] Windows
    Browser [e.g. chrome, safari] Firefox
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Solution/Fix:

The issue is that the sample record is in JSON format and not in the accepted DynamoDB JSON format. A simple tool like "https://dynobase.com/dynamodb-json-converter-tool/ " helps convert the JSON in DynamoDB JSON format.

Accepted DynamoDB JSON format for metering record:

{
"create_timestamp": {
"N": "1645057400"
},
"customerIdentifier": {
"S": "CbGso7gbieE"
},
"dimension_usage": {
"L": [
{
"M": {
"dimension": {
"S": "wuphf"
},
"value": {
"N": "3"
}
}
}
]
},
"metering_pending": {
"S": "true"
}
}

