### PR TITLE
Added support for free trials

### DIFF
--- a/src/grant-revoke-access-to-product.js
+++ b/src/grant-revoke-access-to-product.js
@@ -12,18 +12,19 @@ exports.dynamodbStreamHandler = async (event) => {
     // eslint-disable-next-line no-console
     console.log(`DynamoDb record updated! OldImage: ${JSON.stringify(oldImage)} | NewImage: ${JSON.stringify(newImage)}`);
 
-
     /*
       successfully_subscribed is set true:
-        - for SaaS Contracts: after reciving the entitlement in entitlement-sqs.js for the first time
+        - for SaaS Contracts: no email is sent but after receiving the message in the subscription topic
         - for SaaS Subscriptions: after reciving the subscribe-success message in subscription-sqs.js
 
       subscription_expired is set to true:
         - for SaaS Contracts: after detecting expired entitlement in entitlement-sqs.js
         - for SaaS Subscriptions: after reciving the unsubscribe-success message in subscription-sqs.js
     */
-    const grantAccess = newImage.successfully_subscribed === true
-      && oldImage.successfully_subscribed !== true;
+    const grantAccess = newImage.successfully_subscribed === true && 
+      typeof newImage.is_free_trial_term_present !== "undefined" && 
+      ( oldImage.successfully_subscribed !== true || typeof oldImage.is_free_trial_term_present === "undefined" )
+      
 
     const revokeAccess = newImage.subscription_expired === true
       && !oldImage.subscription_expired;

--- a/src/subscription-sqs.js
+++ b/src/subscription-sqs.js
@@ -41,15 +41,21 @@ exports.SQSHandler = async (event) => {
       throw new Error(`Unhandled action - msg: ${JSON.stringify(record)}`);
     }
 
+    let isFreeTrialTermPresent = false;
+    if (typeof message.isFreeTrialTermPresent === "string")  {
+     isFreeTrialTermPresent = message.isFreeTrialTermPresent.toLowerCase() === "true";
+    }
+
     const dynamoDbParams = {
       TableName: newSubscribersTableName,
       Key: {
         customerIdentifier: { S: message['customer-identifier'] },
       },
-      UpdateExpression: 'set successfully_subscribed = :ss, subscription_expired = :se',
+      UpdateExpression: 'set successfully_subscribed = :ss, subscription_expired = :se, is_free_trial_term_present = :ft',
       ExpressionAttributeValues: {
         ':ss': { BOOL: successfullySubscribed },
         ':se': { BOOL: subscriptionExpired },
+        ':ft': { BOOL: isFreeTrialTermPresent}
       },
       ReturnValues: 'UPDATED_NEW',
     };

--- a/template.yaml
+++ b/template.yaml
@@ -296,7 +296,6 @@ Resources:
 
   SubscriptionSQSHandler:
     Type: AWS::Serverless::Function
-    Condition: CreateSubscriptionLogic
     Properties:
       CodeUri: src
       Handler: subscription-sqs.SQSHandler


### PR DESCRIPTION
To enable free trials support the issue #45 "Enable Subscription SNS topic for SaaS Contract pricing model" was also addressed.

**Description of changes:** 
A new property for SaaS Contract free trials was added to the Subscription SNS topic. The previous implementation of Contracts in the Serverless Integration didn't use the Subscription topic for SaaS Contract. Now this topic is being used and the new free trial flag is added to the DB and to the new subscriptions' notification email. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.