### PR TITLE
subscription notification message changes

### DIFF
--- a/src/grant-revoke-access-to-product.js
+++ b/src/grant-revoke-access-to-product.js
@@ -57,13 +57,13 @@ exports.dynamodbStreamHandler = async (event, context) => {
 
       if (grantAccess) {
         subject = 'New AWS Marketplace Subscriber';
-        message = `Grant access to new SaaS customer: ${JSON.stringify(newImage)}`;
+        message = `subscribe-success: ${JSON.stringify(newImage)}`;
       } else if (revokeAccess) {
         subject = 'AWS Marketplace customer end of subscription';
-        message = `Revoke access to SaaS customer: ${JSON.stringify(newImage)}`;
+        message = `unsubscribe-success: ${JSON.stringify(newImage)}`;
       } else if (entitlementUpdated) {
         subject = 'AWS Marketplace customer change of subscription';
-        message = `New entitlement for customer: ${JSON.stringify(newImage)}`;
+        message = `entitlement-updated: ${JSON.stringify(newImage)}`;
       }
 
       const SNSparams = {

--- a/src/subscription-sqs.js
+++ b/src/subscription-sqs.js
@@ -51,8 +51,9 @@ exports.SQSHandler = async (event) => {
       Key: {
         customerIdentifier: { S: message['customer-identifier'] },
       },
-      UpdateExpression: 'set successfully_subscribed = :ss, subscription_expired = :se, is_free_trial_term_present = :ft',
+      UpdateExpression: 'set subscription_action = :ac, successfully_subscribed = :ss, subscription_expired = :se, is_free_trial_term_present = :ft',
       ExpressionAttributeValues: {
+        ':ac': { S: message['action'] },
         ':ss': { BOOL: successfullySubscribed },
         ':se': { BOOL: subscriptionExpired },
         ':ft': { BOOL: isFreeTrialTermPresent}


### PR DESCRIPTION
*Issue #, if available:* [D71491720](https://t.corp.amazon.com/D71491720)

*Description of changes:*
Changes are made to the Subscription Notification Message to change the title matching the message action. The message action is also stored in the dynamo db so that the payload can contain the subscription message action like: "subscribe-success", "unsubscribe-success" and "entitlement-updated".   

Test notification message attachments - 
![unsubscribe-success_msg](https://user-images.githubusercontent.com/124932971/222770186-16c49f18-f864-4c27-a984-de497e2e44ad.png)
<img width="1276" alt="subscribe-success_msg" src="https://user-images.githubusercontent.com/124932971/222770193-86bfd7ec-d361-47ce-a5af-2f0a205bbd60.png">
<img width="1269" alt="unsubscribe_pending_msg" src="https://user-images.githubusercontent.com/124932971/222770195-c0a23448-7ecd-4ede-a9c5-090cfa17d7e8.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

