### PR TITLE
Fix issue related to S3 Bucket Ownership Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ To build and deploy your application for the first time, run the following in yo
 ```bash
 
 #Replace all `<PLACEHOLDER_VALUES>` with their `actual values` (e.g. `<PROJECT_NAME>` with `My Cool Project`).
+#Create non-public bucket for <DEPLOYMENT_ARTEFACT_S3_BUCKET> before running this script
 
 sam build
 sam package --output-template-file packaged.yaml --s3-bucket <DEPLOYMENT_ARTEFACT_S3_BUCKET>
@@ -207,21 +208,21 @@ aws s3 cp ./web/ s3://<WEBSITE_BUCKET_NAME>/ --recursive
 
 #add a CNAME record to your DNS to route the url you put on your offering to the cloudformation endpoint
 
-#add the domain used for your maretplace URL to the CNAME on the cloudformation config
+#add the domain used for your marketplace URL to the CNAME on the cloudformation config
 ```
 ### List of parameters
 
 Parameter name | Description
 ------------ | -------------
-WebsiteS3BucketName | S3 bucket to store the HTML files; Mandatory if CreateRegistrationWebPage is set to true;
-NewSubscribersTableName | Use custome name for the New Subscribers Table; Default value: AWSMarketplaceSubscribers
-AWSMarketplaceMeteringRecordsTableName | Use custome name for the Metering Records Table; Default value: AWSMarketplaceMeteringRecords
+WebsiteS3BucketName | S3 bucket to store the HTML files; Mandatory if CreateRegistrationWebPage is set to true; will be created
+NewSubscribersTableName | Use customer name for the New Subscribers Table; Default value: AWSMarketplaceSubscribers
+AWSMarketplaceMeteringRecordsTableName | Use customer name for the Metering Records Table; Default value: AWSMarketplaceMeteringRecords
 TypeOfSaaSListing | allowed values: contracts_with_subscription, contracts, subscriptions; Default value: contracts_with_subscription
 ProductCode | Product code provided from AWS Marketplace
-EntitlementSNSTopic | SNS topic ARN provided from AWS Marketplace
-SubscriptionSNSTopic | SNS topic ARN provided from AWS Marketplace
+EntitlementSNSTopic | SNS topic ARN provided from AWS Marketplace. Must exist.
+SubscriptionSNSTopic | SNS topic ARN provided from AWS Marketplace. Must exist.
 CreateRegistrationWebPage | true or false; Default value: true
-MarketplaceTechAdminEmail | Email to be notified on changes requring action
+MarketplaceTechAdminEmail | Email to be notified on changes requiring action
 MarketplaceSellerEmail | Seller SES verified email address
 
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ EntitlementSNSTopic | SNS topic ARN provided from AWS Marketplace. Must exist.
 SubscriptionSNSTopic | SNS topic ARN provided from AWS Marketplace. Must exist.
 CreateRegistrationWebPage | true or false; Default value: true
 MarketplaceTechAdminEmail | Email to be notified on changes requiring action
-MarketplaceSellerEmail | Seller SES verified email address
+MarketplaceSellerEmail | Seller email address, verified in SES and in 'Production' mode
 
 
 ### Diagram of created resources

--- a/src/grant-revoke-access-to-product.js
+++ b/src/grant-revoke-access-to-product.js
@@ -57,13 +57,13 @@ exports.dynamodbStreamHandler = async (event, context) => {
 
       if (grantAccess) {
         subject = 'New AWS Marketplace Subscriber';
-        message = `Grant access to new SaaS customer: ${JSON.stringify(newImage)}`;
+        message = `subscribe-success: ${JSON.stringify(newImage)}`;
       } else if (revokeAccess) {
         subject = 'AWS Marketplace customer end of subscription';
-        message = `Revoke access to SaaS customer: ${JSON.stringify(newImage)}`;
+        message = `unsubscribe-success: ${JSON.stringify(newImage)}`;
       } else if (entitlementUpdated) {
         subject = 'AWS Marketplace customer change of subscription';
-        message = `New entitlement for customer: ${JSON.stringify(newImage)}`;
+        message = `entitlement-updated: ${JSON.stringify(newImage)}`;
       }
 
       const SNSparams = {

--- a/src/subscription-sqs.js
+++ b/src/subscription-sqs.js
@@ -51,8 +51,9 @@ exports.SQSHandler = async (event) => {
       Key: {
         customerIdentifier: { S: message['customer-identifier'] },
       },
-      UpdateExpression: 'set successfully_subscribed = :ss, subscription_expired = :se, is_free_trial_term_present = :ft',
+      UpdateExpression: 'set subscription_action = :ac, successfully_subscribed = :ss, subscription_expired = :se, is_free_trial_term_present = :ft',
       ExpressionAttributeValues: {
+        ':ac': { S: message['action'] },
         ':ss': { BOOL: successfullySubscribed },
         ':se': { BOOL: subscriptionExpired },
         ':ft': { BOOL: isFreeTrialTermPresent}

--- a/template.yaml
+++ b/template.yaml
@@ -137,6 +137,9 @@ Resources:
     Condition: CreateWeb
     Properties:
       BucketName: !Join ["-", [!Ref WebsiteS3BucketName, "log"]]
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       IntelligentTieringConfigurations:
         - Id: !Join ["-", [!Ref WebsiteS3BucketName, "log"]]
           Status: Enabled


### PR DESCRIPTION
*Issue #, if available:* The S3 bucket for CloudFront logs is failing due to security policy introduced in April 2023 for s3 bucket security best practices.  

*Description of changes:* All newly created buckets in the Region will by default have [S3 Block Public Access](https://aws.amazon.com/blogs/aws/amazon-s3-block-public-access-another-layer-of-protection-for-your-accounts-and-buckets/) enabled and [access control lists](https://aws.amazon.com/blogs/aws/new-simplify-access-management-for-data-stored-in-amazon-s3/) (ACLs) disabled. This is causing the SAAS quick-start to fail during the stage where Cloudfront Distribution is created in AWS cloudformation stack. The S3 bucket for CloudFront logs does not enable ACL access.  Hence, the current fix is made. 
https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
