### PR TITLE
removed stack name dependency and replaced with unique ID segment fro…

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -472,8 +472,32 @@ Resources:
     Type: "AWS::CloudFront::OriginAccessControl"
     Properties: 
       OriginAccessControlConfig: 
-        Description: !Sub "Origin Access Control for static website - ${AWS::StackName}"
-        Name: !Sub "OAC - ${AWS::StackName}"
+        Description:
+         !Join
+          - '-'
+          - - 'Origin Access Control for static website'
+            - !Select 
+              - 0
+              - !Split 
+                - "-"
+                - !Select
+                  - 2
+                  - !Split
+                    - "/"
+                    - !Ref AWS::StackId
+        Name:
+         !Join
+          - '-'
+          - - 'OAC'
+            - !Select 
+              - 0
+              - !Split 
+                - "-"
+                - !Select
+                  - 2
+                  - !Split
+                    - "/"
+                    - !Ref AWS::StackId
         OriginAccessControlOriginType: "s3"
         SigningBehavior: "always"
         SigningProtocol: "sigv4"
@@ -485,7 +509,19 @@ Resources:
     DependsOn: ServerlessApi
     Properties:
       DistributionConfig:
-        Comment: !Sub "Cloudfront distribution for serverless website - ${AWS::StackName}"
+        Comment:
+         !Join
+          - '-'
+          - - 'Cloudfront distribution for serverless website'
+            - !Select 
+              - 0
+              - !Split 
+                - "-"
+                - !Select
+                  - 2
+                  - !Split
+                    - "/"
+                    - !Ref AWS::StackId
         DefaultRootObject: "index.html"
         Enabled: true
         HttpVersion: http2

--- a/template.yaml
+++ b/template.yaml
@@ -401,8 +401,7 @@ Resources:
       QueueName:
        !Join
         - '-'
-        - - 'SQSMeteringRecords.fifo'
-          - !Select 
+        - - !Select 
             - 0
             - !Split 
               - "-"
@@ -411,6 +410,7 @@ Resources:
                 - !Split
                   - "/"
                   - !Ref AWS::StackId
+          - 'SQSMeteringRecords.fifo'
       ContentBasedDeduplication: true
       FifoQueue: true
       MessageRetentionPeriod: 3000

--- a/template.yaml
+++ b/template.yaml
@@ -122,7 +122,19 @@ Resources:
      - AWSMarketplaceMeteringRecords 
      - AWSMarketplaceSubscribers
     Properties:
-      RoleName: !Join ["-", [!Ref "AWS::StackName", !Ref CrossAccountRoleName]]
+      RoleName:
+         !Join
+          - '-'
+          - - 'CrossAccountRoleName'
+            - !Select 
+              - 0
+              - !Split 
+                - "-"
+                - !Select
+                  - 2
+                  - !Split
+                    - "/"
+                    - !Ref AWS::StackId
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -137,7 +149,19 @@ Resources:
                 'sts:ExternalId': !Ref CrossAccountRoleName
       Path: /
       Policies:
-        - PolicyName: !Join ["-", [!Ref "AWS::StackName", "CrossAccountPolicy"]]
+        - PolicyName:
+           !Join
+            - '-'
+            - - 'CrossAccountPolicy'
+              - !Select 
+                - 0
+                - !Split 
+                  - "-"
+                  - !Select
+                    - 2
+                    - !Split
+                      - "/"
+                      - !Ref AWS::StackId
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -355,14 +379,38 @@ Resources:
           Type: Schedule
           Properties:
             Schedule: "rate(1 hour)"
-            Name: !Join ["-", [MeteringSchedule, !Ref AWS::StackName]]
+            Name:
+             !Join
+              - '-'
+              - - 'MeteringSchedule'
+                - !Select 
+                  - 0
+                  - !Split 
+                    - "-"
+                    - !Select
+                      - 2
+                      - !Split
+                        - "/"
+                        - !Ref AWS::StackId
             Description: SaaS Metering
             Enabled: true
 
   SQSMeteringRecords:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Join ["-", [!Ref AWS::StackName, SQSMeteringRecords.fifo]]
+      QueueName:
+       !Join
+        - '-'
+        - - 'SQSMeteringRecords.fifo'
+          - !Select 
+            - 0
+            - !Split 
+              - "-"
+              - !Select
+                - 2
+                - !Split
+                  - "/"
+                  - !Ref AWS::StackId
       ContentBasedDeduplication: true
       FifoQueue: true
       MessageRetentionPeriod: 3000


### PR DESCRIPTION
…m stack arn instead

*Issue #, if available:*
29 - long stack names cause the application to fail

*Description of changes:*
change the naming method for cloudfront origin to remove the stackname dependency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
