### PR TITLE
Fix conflicting conditional operation issue for WebsiteS3Bucket resource

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -461,7 +461,11 @@ Resources:
     Type: AWS::S3::Bucket
     Condition: CreateWeb
     Properties:
-      BucketName: !Ref WebsiteS3BucketName
+      BucketName:
+        !If
+          - CreateWeb
+          - !Ref WebsiteS3BucketName
+          - !Ref AWS::NoValue
 
   WebsiteS3BucketLog:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
*Issue #86 :*

*Description of changes:*
`template.yaml` now checks whether the `CreateWeb` parameter is set to `true` before using the reference to `WebsiteS3BucketName` in the `WebsiteS3Bucket` resource.  This resolves the conflicting conditional operation issue with CLoudFormation that causes the deployment to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
